### PR TITLE
Improve head builds

### DIFF
--- a/.github/workflows/head-builds.yaml
+++ b/.github/workflows/head-builds.yaml
@@ -17,23 +17,7 @@ permissions:
   contents: write
 
 jobs:
-  prebuild-env:
-    name: Prebuild needed Env vars
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repository to the runner
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Set Branch Tag and Other Variables
-        id: set-vars
-        run: bash ./.github/scripts/branch-tags.sh >> $GITHUB_OUTPUT
-    outputs:
-      branch_tag: ${{ steps.set-vars.outputs.branch_tag }}
-      branch_static_tag: ${{ steps.set-vars.outputs.branch_static_tag }}
-      prev_tag: ${{ steps.set-vars.outputs.prev_tag }}
   push:
-    needs : [
-      prebuild-env,
-    ]
     permissions:
       contents : read
       id-token: write
@@ -42,6 +26,10 @@ jobs:
     steps:
       - name : Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Set Branch Tag and Other Variables
+        id: set-vars
+        run: bash ./.github/scripts/branch-tags.sh >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
@@ -77,7 +65,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.FULL_IMAGE_PATH }}:${{ needs.prebuild-env.outputs.branch_static_tag }}
-            ${{ env.FULL_IMAGE_PATH }}:${{ needs.prebuild-env.outputs.branch_tag }}
-            ghcr.io/${{ env.FULL_IMAGE_PATH }}:${{ needs.prebuild-env.outputs.branch_static_tag }}
-            ghcr.io/${{ env.FULL_IMAGE_PATH }}:${{ needs.prebuild-env.outputs.branch_tag }}
+            ${{ env.FULL_IMAGE_PATH }}:${{ steps.set-vars.outputs.branch_static_tag }}
+            ${{ env.FULL_IMAGE_PATH }}:${{ steps.set-vars.outputs.branch_tag }}
+            ghcr.io/${{ env.FULL_IMAGE_PATH }}:${{ steps.set-vars.outputs.branch_static_tag }}
+            ghcr.io/${{ env.FULL_IMAGE_PATH }}:${{ steps.set-vars.outputs.branch_tag }}

--- a/.github/workflows/head-builds.yaml
+++ b/.github/workflows/head-builds.yaml
@@ -44,8 +44,8 @@ jobs:
         uses: rancher-eio/read-vault-secrets@main
         with:
           secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/credentials username | DOCKER_USERNAME ;
+            secret/data/github/repo/${{ github.repository }}/dockerhub/credentials password | DOCKER_PASSWORD
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,13 +16,37 @@ builds:
       ldflags:
         - -extldflags
         - -static
-        - -s -w -X github.com/rancher/scc-operator/cmd/operator/version.Version={{.Version}}
-        - -s -w -X github.com/rancher/scc-operator/cmd/operator/version.Commit={{.Commit}}
-        - -s -w -X github.com/rancher/scc-operator/cmd/operator/version.Date={{.Date}}
+        - -s -w
+        - -X github.com/rancher/scc-operator/cmd/operator/version.Version={{.Version}}
+        - -X github.com/rancher/scc-operator/cmd/operator/version.Commit={{.Commit}}
+        - -X github.com/rancher/scc-operator/cmd/operator/version.Date={{.Date}}
       flags:
         - -trimpath
       env:
         - CGO_ENABLED=0
+
+  # macOS build, only when GOOS_DARWIN_DEV is set
+    - id: scc-operator-darwin
+      main: ./cmd/operator/main.go
+      goos:
+        - darwin
+      goarch:
+        - amd64
+        - arm64
+      binary: scc-operator
+      ldflags:
+        - -extldflags
+        - -static
+        - -s -w
+        - -X github.com/rancher/scc-operator/cmd/operator/version.Version={{.Version}}
+        - -X github.com/rancher/scc-operator/cmd/operator/version.Commit={{.Commit}}
+        - -X github.com/rancher/scc-operator/cmd/operator/version.Date={{.Date}}
+      flags:
+        - -trimpath
+      env:
+        - CGO_ENABLED=0
+      skip: '{{ not (index .Env "GOOS_DARWIN_DEV") }}'
+
 archives:
     - id: scc-operator
       builds:


### PR DESCRIPTION
speeds up head builds where the env setup script can be a single step in the job and not need to be re-used among multiple jobs.

Also add darwin debug target (default disabled) - this mimics what I added to BRO for easier local debug of build processes (by setting the env var)