### PR TITLE
[main] Fix nil access causing lots of logs

### DIFF
--- a/internal/wrangler/polyfill/polyfill.go
+++ b/internal/wrangler/polyfill/polyfill.go
@@ -2,22 +2,25 @@ package polyfill
 
 import (
 	"context"
+	"strings"
 
 	"github.com/rancher/wrangler/v3/pkg/generic"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // ScopeFunc is a function that determines whether a scoped handler should trigger
 type ScopeFunc func(key string, obj runtime.Object) (bool, error)
 
-func InExpectedNamespace(obj runtime.Object, namespace string) bool {
-	metadata, err := meta.Accessor(obj)
-	if err != nil {
-		return false
+func InExpectedNamespace(nameIn string, _ runtime.Object, namespace string) bool {
+	var namespaceIn string
+	if strings.Contains(nameIn, "/") {
+		parts := strings.Split(nameIn, "/")
+		namespaceIn = parts[0]
+	} else {
+		namespaceIn = nameIn
 	}
 
-	return metadata.GetNamespace() == namespace
+	return namespaceIn == namespace
 }
 
 func ScopedOnChange[T generic.RuntimeMetaObject](ctx context.Context, name string, inScopeFunc ScopeFunc, c generic.ControllerMeta, sync generic.ObjectHandler[T]) {

--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -113,8 +113,8 @@ func Register(
 	controller.initIndexers()
 	controller.initResolvers(ctx)
 
-	withinExpectedNamespaceCondition := func(_ string, obj runtime.Object) (bool, error) {
-		if !wranglerPolyfill.InExpectedNamespace(obj, controller.options.SystemNamespace) {
+	withinExpectedNamespaceCondition := func(name string, obj runtime.Object) (bool, error) {
+		if !wranglerPolyfill.InExpectedNamespace(name, obj, controller.options.SystemNamespace) {
 			return false, nil
 		}
 		return true, nil
@@ -125,6 +125,9 @@ func Register(
 	// TODO: pull out registration controllers to register only when system is ready
 	// TODO: also add a watcher to trigger enqueue on related resource changes
 	withinOperatorScopeCondition := func(_ string, obj runtime.Object) (bool, error) {
+		if obj == nil {
+			return false, nil
+		}
 		metaObj, err := meta.Accessor(obj)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
This corrects 2 scoped wrangler handlers that had potentially nil accessors causing lots of logs.
Particularly this would happen a lot after deleting a Registration.