### PR TITLE
[main] fix default reference to the operator name and namespace

### DIFF
--- a/internal/repos/secretrepo/secrets.go
+++ b/internal/repos/secretrepo/secrets.go
@@ -6,6 +6,7 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/rancher/scc-operator/internal/consts"
+	"github.com/rancher/scc-operator/internal/initializer"
 	"github.com/rancher/scc-operator/internal/telemetry"
 	corev1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -103,11 +104,11 @@ func (r *SecretRepository) CreateOrUpdateSecret(secret *v1.Secret) (*v1.Secret, 
 }
 
 func (r *SecretRepository) HasMetricsSecret() bool {
-	return r.HasSecret(consts.DefaultSCCNamespace, consts.SCCMetricsOutputSecretName)
+	return r.HasSecret(initializer.SystemNamespace.Get(), consts.SCCMetricsOutputSecretName)
 }
 
 func (r *SecretRepository) FetchMetricsSecret() (telemetry.MetricsWrapper, error) {
-	metricsSecret, err := r.Get(consts.DefaultSCCNamespace, consts.SCCMetricsOutputSecretName)
+	metricsSecret, err := r.Get(initializer.SystemNamespace.Get(), consts.SCCMetricsOutputSecretName)
 	if err != nil {
 		return telemetry.MetricsWrapper{}, err
 	}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/rancher/scc-operator/internal/consts"
+	"github.com/rancher/scc-operator/internal/initializer"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -55,7 +56,7 @@ func (s *SecretRequester) prepareSecretRequestUnstructured() *unstructured.Unstr
 			"spec": map[string]interface{}{
 				"secretType": "scc",
 				"targetSecretRef": map[string]interface{}{
-					"namespace": consts.DefaultSCCNamespace,
+					"namespace": initializer.SystemNamespace.Get(),
 					"name":      consts.SCCMetricsOutputSecretName,
 				},
 			},

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -40,7 +40,7 @@ func (s *SccStarter) hasSccMetricsSecretPopulated() bool {
 
 func (s *SccStarter) EnsureMetricsSecretRequest(ctx context.Context) error {
 	labels := map[string]string{
-		consts.LabelK8sManagedBy: consts.DefaultOperatorName,
+		consts.LabelK8sManagedBy: s.options.OperatorName,
 	}
 	metricsRequester := telemetry.NewSecretRequester(
 		labels,


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/51449

as part of the issue. I also did some tests involving two operators running on the same cluster.

Tests were performed using the same namespaces, different namespaces and rancher and non-rancher namespaces. There were no CRD conflicts.

Customization of **SCC_OPERATOR_NAME**, **SCC_SYSTEM_NAMESPACE**, and **SCC_LEASE_NAMESPACE** worked correctly.

controllers of **shouldManage** scope worked as expected.