### PR TITLE
[release/v0.1.x] Offer rancher versioning override alternative

### DIFF
--- a/internal/telemetry/scc.go
+++ b/internal/telemetry/scc.go
@@ -1,6 +1,8 @@
 package telemetry
 
 import (
+	"os"
+
 	"github.com/SUSE/connect-ng/pkg/registration"
 	"github.com/rancher/scc-operator/internal/rancher"
 )
@@ -26,6 +28,11 @@ func NewMetricsWrapper(data map[string]any) MetricsWrapper {
 	subInfo.version = subscriptionData["version"].(string)
 	subInfo.arch = subscriptionData["arch"].(string)
 	subInfo.git = subscriptionData["git"].(string)
+
+	rancherVersionOverride := os.Getenv("SCC_RANCHER_VERSION_OVERRIDE")
+	if rancherVersionOverride != "" {
+		subInfo.version = rancherVersionOverride
+	}
 
 	return MetricsWrapper{
 		Data:             data,


### PR DESCRIPTION
This is a first step towards the goal of improving how the Rancher Version is handled by the scc-operator. 

We want to especially improve QA testing experience when testing non-production Rancher builds in the production environment. This small and hacky fix should only apply to the `release/v0.1.x` branch and will be improved for the next minor Rancher release.

It's related to #24 but doesn't cover the entire issue.