### PR TITLE
[main] Correct bug where Rancher "product version" includes a "v" prefix

### DIFF
--- a/internal/rancher/version.go
+++ b/internal/rancher/version.go
@@ -2,6 +2,7 @@ package rancher
 
 import (
 	"regexp"
+	"strings"
 )
 
 // semverRegex matches on regular SemVer as well as Rancher's dev versions
@@ -26,6 +27,9 @@ func (rv Version) versionIsDevBuild() bool {
 func (rv Version) SCCSafeVersion() string {
 	if rv.versionIsDevBuild() {
 		return "other"
+	}
+	if strings.HasPrefix(string(rv), "v") {
+		return strings.TrimPrefix(string(rv), "v")
 	}
 	return string(rv)
 }

--- a/internal/rancher/version_test.go
+++ b/internal/rancher/version_test.go
@@ -1,0 +1,58 @@
+package rancher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRancherVersion(t *testing.T) {
+	asserts := assert.New(t)
+
+	var tests = []struct {
+		name       string
+		input      string
+		isDevBuild bool
+		sccVersion string
+	}{
+		{
+			"Dev IDE",
+			"dev",
+			true,
+			"other",
+		},
+		{
+			"Dev Build/Head Images",
+			"v2.12-207d1eaa2-head",
+			true,
+			"other",
+		},
+		{
+			"Alpha Build",
+			"v2.12.1-alpha4",
+			true,
+			"other",
+		},
+		{
+			"Release",
+			"v2.12.1",
+			false,
+			"2.12.1",
+		},
+		{
+			"Manual Override",
+			"2.13.1",
+			false,
+			"2.13.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testVersion := Version(tt.input)
+			asserts.Equal(tt.isDevBuild, testVersion.versionIsDevBuild())
+			asserts.Equal(tt.sccVersion, testVersion.SCCSafeVersion())
+		})
+	}
+
+}

--- a/internal/telemetry/scc.go
+++ b/internal/telemetry/scc.go
@@ -1,8 +1,6 @@
 package telemetry
 
 import (
-	"strings"
-
 	"github.com/SUSE/connect-ng/pkg/registration"
 	"github.com/rancher/scc-operator/internal/rancher"
 )
@@ -18,7 +16,6 @@ type subscriptionInfo struct {
 type MetricsWrapper struct {
 	Data             map[string]any
 	subscriptionInfo subscriptionInfo
-	rancherVersion   string
 }
 
 func NewMetricsWrapper(data map[string]any) MetricsWrapper {
@@ -33,7 +30,6 @@ func NewMetricsWrapper(data map[string]any) MetricsWrapper {
 	return MetricsWrapper{
 		Data:             data,
 		subscriptionInfo: subInfo,
-		rancherVersion:   strings.TrimPrefix(subInfo.version, "v"),
 	}
 }
 
@@ -47,6 +43,6 @@ func (mw *MetricsWrapper) ToSystemInformation() registration.SystemInformation {
 
 // GetProductIdentifier must return the SCC Product ID, the Product version, and product arch
 func (mw *MetricsWrapper) GetProductIdentifier() (string, string, string) {
-	rancherVersion := rancher.Version(mw.rancherVersion)
+	rancherVersion := rancher.Version(mw.subscriptionInfo.version)
 	return mw.subscriptionInfo.product, rancherVersion.SCCSafeVersion(), mw.subscriptionInfo.arch
 }


### PR DESCRIPTION
## Issue: https://github.com/rancher/scc-operator/issues/32

### Solution
Ensure that Metrics wrapper handles Rancher version translation for SCC product