### PR TITLE
[Backport] Correct bug where Rancher "product version" includes a "v" prefix

### DIFF
--- a/internal/rancher/version.go
+++ b/internal/rancher/version.go
@@ -2,6 +2,7 @@ package rancher
 
 import (
 	"regexp"
+	"strings"
 )
 
 // semverRegex matches on regular SemVer as well as Rancher's dev versions
@@ -26,6 +27,9 @@ func (rv Version) versionIsDevBuild() bool {
 func (rv Version) SCCSafeVersion() string {
 	if rv.versionIsDevBuild() {
 		return "other"
+	}
+	if strings.HasPrefix(string(rv), "v") {
+		return strings.TrimPrefix(string(rv), "v")
 	}
 	return string(rv)
 }

--- a/internal/rancher/version_test.go
+++ b/internal/rancher/version_test.go
@@ -1,0 +1,58 @@
+package rancher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRancherVersion(t *testing.T) {
+	asserts := assert.New(t)
+
+	var tests = []struct {
+		name       string
+		input      string
+		isDevBuild bool
+		sccVersion string
+	}{
+		{
+			"Dev IDE",
+			"dev",
+			true,
+			"other",
+		},
+		{
+			"Dev Build/Head Images",
+			"v2.12-207d1eaa2-head",
+			true,
+			"other",
+		},
+		{
+			"Alpha Build",
+			"v2.12.1-alpha4",
+			true,
+			"other",
+		},
+		{
+			"Release",
+			"v2.12.1",
+			false,
+			"2.12.1",
+		},
+		{
+			"Manual Override",
+			"2.13.1",
+			false,
+			"2.13.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testVersion := Version(tt.input)
+			asserts.Equal(tt.isDevBuild, testVersion.versionIsDevBuild())
+			asserts.Equal(tt.sccVersion, testVersion.SCCSafeVersion())
+		})
+	}
+
+}

--- a/internal/telemetry/scc.go
+++ b/internal/telemetry/scc.go
@@ -1,8 +1,6 @@
 package telemetry
 
 import (
-	"strings"
-
 	"github.com/SUSE/connect-ng/pkg/registration"
 	"github.com/rancher/scc-operator/internal/rancher"
 )
@@ -18,7 +16,6 @@ type subscriptionInfo struct {
 type MetricsWrapper struct {
 	Data             map[string]any
 	subscriptionInfo subscriptionInfo
-	rancherVersion   string
 }
 
 func NewMetricsWrapper(data map[string]any) MetricsWrapper {
@@ -33,7 +30,6 @@ func NewMetricsWrapper(data map[string]any) MetricsWrapper {
 	return MetricsWrapper{
 		Data:             data,
 		subscriptionInfo: subInfo,
-		rancherVersion:   strings.TrimPrefix(subInfo.version, "v"),
 	}
 }
 
@@ -47,6 +43,6 @@ func (mw *MetricsWrapper) ToSystemInformation() registration.SystemInformation {
 
 // GetProductIdentifier must return the SCC Product ID, the Product version, and product arch
 func (mw *MetricsWrapper) GetProductIdentifier() (string, string, string) {
-	rancherVersion := rancher.Version(mw.rancherVersion)
+	rancherVersion := rancher.Version(mw.subscriptionInfo.version)
 	return mw.subscriptionInfo.product, rancherVersion.SCCSafeVersion(), mw.subscriptionInfo.arch
 }

--- a/internal/telemetry/scc.go
+++ b/internal/telemetry/scc.go
@@ -1,6 +1,8 @@
 package telemetry
 
 import (
+	"strings"
+
 	"github.com/SUSE/connect-ng/pkg/registration"
 	"github.com/rancher/scc-operator/internal/rancher"
 )
@@ -16,6 +18,7 @@ type subscriptionInfo struct {
 type MetricsWrapper struct {
 	Data             map[string]any
 	subscriptionInfo subscriptionInfo
+	rancherVersion   string
 }
 
 func NewMetricsWrapper(data map[string]any) MetricsWrapper {
@@ -30,6 +33,7 @@ func NewMetricsWrapper(data map[string]any) MetricsWrapper {
 	return MetricsWrapper{
 		Data:             data,
 		subscriptionInfo: subInfo,
+		rancherVersion:   strings.TrimPrefix(subInfo.version, "v"),
 	}
 }
 
@@ -43,6 +47,6 @@ func (mw *MetricsWrapper) ToSystemInformation() registration.SystemInformation {
 
 // GetProductIdentifier must return the SCC Product ID, the Product version, and product arch
 func (mw *MetricsWrapper) GetProductIdentifier() (string, string, string) {
-	rancherVersion := rancher.Version(mw.subscriptionInfo.version)
+	rancherVersion := rancher.Version(mw.rancherVersion)
 	return mw.subscriptionInfo.product, rancherVersion.SCCSafeVersion(), mw.subscriptionInfo.arch
 }


### PR DESCRIPTION
A backport of: https://github.com/rancher/scc-operator/pull/33

While we don't have a method to push OTA updates to users for just one component, we could provide a fixed image tag that customers could opt-in to fix the issue sooner than the next release.

We would have to:

1. Merge this,
2. Create a new alpha/RC image (`v0.1.2`),
3. Get QA to validate the bug fix on 2.12.1 release (via settings patching),
4. Release a stable tag version,
5. (Potentially) Work with release team to sync the image to Prime from Staging Prime (since this is normally part of release process),
6. Write a KB to cover the kubectl command to run to update the Rancher Setting that controls SCC Operator image tag