### PR TITLE
Improve failed registration logging and logic

### DIFF
--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -558,7 +558,11 @@ func (h *handler) OnRegistrationChange(_ string, registrationObj *v1.Registratio
 
 	if shared.RegistrationIsFailed(registrationObj) {
 		failedCondition := registrationObj.Status.CurrentCondition
-		h.log.Errorf("registration `%s` has the Failure status condition from: %v", registrationObj.Name, failedCondition)
+		if failedCondition != nil {
+			h.log.Errorf("registration `%s` has the Failure status condition from: %v", registrationObj.Name, failedCondition)
+		} else {
+			h.log.Errorf("registration `%s` has the Failure status condition active", registrationObj.Name)
+		}
 		h.log.Warnf("reviewing the registration `%s` for other errors is advised before retrying", registrationObj.Name)
 
 		errorFixHint := fmt.Sprintf("delete this registration `%s` and then create a new one to try again.", registrationObj.Name)

--- a/pkg/controllers/controller.go
+++ b/pkg/controllers/controller.go
@@ -563,7 +563,7 @@ func (h *handler) OnRegistrationChange(_ string, registrationObj *v1.Registratio
 
 		errorFixHint := fmt.Sprintf("delete this registration `%s` and then create a new one to try again.", registrationObj.Name)
 		if shared.RegistrationHasManagedFinalizer(registrationObj) {
-			errorFixHint = fmt.Sprintf("delete the entrypoint secret `%s/%s`, give it time to clean up, and then create a new one to try again.", consts.DefaultSCCNamespace, consts.ResourceSCCEntrypointSecretName)
+			errorFixHint = fmt.Sprintf("delete the entrypoint secret `%s/%s`, give it time to clean up, and then create a new one to try again.", h.options.SystemNamespace, consts.ResourceSCCEntrypointSecretName)
 		}
 		h.log.Warn("after resolving the issue(s), " + errorFixHint)
 		return registrationObj, nil


### PR DESCRIPTION
## Issue
https://github.com/rancher/scc-operator/issues/46

This is fixing a bug inadverdently reported in that issue, so keep that in mind when reviewing and testing. Going into this we know this may only fix part of the reporters issue. The main value is that it will make any other issues the reporter (or other users) is experiencing **way** more obvious.

## Fix
Improve the RegistrationIsFailed error logs and prevent infinite re-queue of failed objects