### PR TITLE
Adopt hardened-build-base to get correct go toolchain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
 
   release:
     name: Un-draft release
-    runs-on: runs-on,image=ubuntu22-full-x64,runner=4cpu-linux-x64,run-id=${{ github.run_id }}
+    runs-on: ubuntu-latest
     needs: [ ci, goreleaser, image ]
     permissions:
       contents: write

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.25 AS builder
+FROM rancher/hardened-build-base:v1.25.10b1 AS builder
 
 ARG TAG=''
 ARG REPO=''


### PR DESCRIPTION
- Fixes failed attempt to bump go toolchain via `go.mod`
- switches undraft step/job to use `ubuntu-latest` to fix issue that was blocking them