### PR TITLE
Automate release PRs to `r/r` repo

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # The FOSSA token is shared between all repos in Rancher's GH org. It can be
     # used directly and there is no need to request specific access to EIO.

--- a/.github/workflows/head-builds.yml
+++ b/.github/workflows/head-builds.yml
@@ -29,16 +29,16 @@ jobs:
       image: ghcr.io/rancher/ci-image/go1.25
     steps:
       - name : Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set Branch Tag and Other Variables
         id: set-vars
         run: bash ./.github/scripts/branch-tags.sh >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -52,7 +52,7 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
 
       - name: Login to Docker Hub
-        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ env.DOCKER_USERNAME || vars.DOCKER_USERNAME || github.repository_owner }}
           password: ${{ env.DOCKER_PASSWORD || secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
     container:
       image: ghcr.io/rancher/ci-image/go1.25
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: golangci-lint
         run:

--- a/.github/workflows/push-to-rancher.yml
+++ b/.github/workflows/push-to-rancher.yml
@@ -1,0 +1,56 @@
+name: Push to rancher/rancher
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'SCC Operator tag to sync (e.g. v0.4.2-rc.1)'
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        description: 'SCC Operator tag to sync'
+        required: true
+        type: string
+
+jobs:
+  push-to-rancher:
+    name: Push to rancher/rancher
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    container:
+      image: ghcr.io/rancher/ci-image/go1.25
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Read GitHub App Credentials from Vault
+        if: github.repository == 'rancher/scc-operator'
+        uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+        with:
+          secrets: |
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APPID;
+            secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATEKEY
+
+      - name: Generate GitHub App Token
+        if: github.repository == 'rancher/scc-operator'
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ env.APPID }}
+          private-key: ${{ env.PRIVATEKEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: rancher
+
+      - name: Push updates to rancher/rancher
+        if: github.repository == 'rancher/scc-operator'
+        env:
+          TAG: ${{ inputs.tag }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          SOURCE_REPO: ${{ github.repository }}
+          SCC_DIR: ${{ github.workspace }}
+          RANCHER_DIR: ${{ github.workspace }}/rancher-repo
+        run: ./.github/workflows/push-to-rancher/run-gha.sh

--- a/.github/workflows/push-to-rancher.yml
+++ b/.github/workflows/push-to-rancher.yml
@@ -25,7 +25,7 @@ jobs:
       image: ghcr.io/rancher/ci-image/go1.25
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Read GitHub App Credentials from Vault
         if: github.repository == 'rancher/scc-operator'

--- a/.github/workflows/push-to-rancher/README.md
+++ b/.github/workflows/push-to-rancher/README.md
@@ -1,0 +1,89 @@
+# push-to-rancher
+
+Automates opening PRs against [rancher/rancher](https://github.com/rancher/rancher) when a new SCC Operator release is published.
+
+## Workflows
+
+### `.github/workflows/push-to-rancher.yml`
+
+Standalone workflow that can be:
+- **Manually triggered** via `workflow_dispatch` with any tag (including RCs)
+- **Called** from other workflows (e.g., `release.yml` for stable releases)
+
+### `.github/workflows/release.yml`
+
+Automatically calls `push-to-rancher.yml` for stable releases only (after images are published and release is un-drafted).
+
+## How it works
+
+For each target Rancher branch:
+1. Clone rancher/rancher
+2. Update `defaultSccOperatorImage` in `build.yaml`
+3. Run `go generate ./pkg/...` to update generated files
+4. Commit changes
+5. Push branch and create PR
+
+## Target branches
+
+Edit `common.sh` and update `RANCHER_BRANCHES` array:
+
+```bash
+RANCHER_BRANCHES=(
+  "release/v2.12"
+  "release/v2.13"
+  "release/v2.14"
+  "release/v2.15"
+  "main"
+)
+```
+
+Add new Rancher versions as they're released. Remove EOL versions.
+
+## Local usage
+
+```bash
+./.github/workflows/push-to-rancher/run-local.sh \
+  --tag v0.4.2 \
+  --rancher-dir /path/to/rancher \
+  [--dry-run] \
+  [--remote upstream]
+```
+
+`--dry-run` runs all local git work (commits to your rancher clone) but skips push and PR creation.
+
+## Step sequence
+
+| Script | What it does |
+|---|---|
+| `update-build-yaml.sh` | Updates `defaultSccOperatorImage` in `build.yaml` using `yq` |
+| `create-prs.sh` | For each target branch: checkout, update, `go generate`, commit, push, create PR |
+| `run-gha.sh` | GHA entry point: validates image exists, clones rancher/rancher, calls create-prs.sh |
+| `run-local.sh` | Local entry point: parses args, sets up env, calls create-prs.sh |
+
+## Key env vars
+
+| Var | Description |
+|---|---|
+| `TAG` | SCC Operator tag (e.g. `v0.4.2`) |
+| `RANCHER_DIR` | Path to local rancher/rancher clone |
+| `RANCHER_REMOTE` | Remote name in `RANCHER_DIR` (default: `origin`) |
+| `DRY_RUN` | Set to `true` to skip push and PR creation |
+| `SOURCE_REPO` | Source repo for PR body (default: `rancher/scc-operator`) |
+
+## GHA prerequisites
+
+The workflow reads a GitHub App credential from Vault at:
+
+```
+secret/data/github/repo/rancher/scc-operator/github/app-credentials
+```
+
+The app must have write access to `rancher/rancher` to push branches and open PRs.
+
+## Error handling
+
+The workflow continues processing branches even if one fails. Failed branches are logged at the end of the run. Common failure modes:
+
+- Branch doesn't exist (e.g., when a new Rancher version isn't released yet)
+- `go generate` fails (rare, usually indicates build.yaml format change)
+- PR already exists for this tag on this branch

--- a/.github/workflows/push-to-rancher/README.md
+++ b/.github/workflows/push-to-rancher/README.md
@@ -25,10 +25,10 @@ For each target Rancher branch:
 
 ## Target branches
 
-Edit `common.sh` and update `RANCHER_BRANCHES` array:
+Default branches are defined in `common.sh`:
 
 ```bash
-RANCHER_BRANCHES=(
+DEFAULT_RANCHER_BRANCHES=(
   "release/v2.12"
   "release/v2.13"
   "release/v2.14"
@@ -39,6 +39,28 @@ RANCHER_BRANCHES=(
 
 Add new Rancher versions as they're released. Remove EOL versions.
 
+### Filtering branches at runtime
+
+Override which branches to process using `RANCHER_BRANCHES_OVERRIDE`:
+
+**Local usage:**
+```bash
+# Only v2.15 and main
+./run-local.sh --tag v0.4.2 --rancher-dir ~/rancher \
+  --branches "release/v2.15,main"
+
+# Single branch
+./run-local.sh --tag v0.4.2 --rancher-dir ~/rancher \
+  --branches "main"
+```
+
+**GHA usage:**
+Set `RANCHER_BRANCHES_OVERRIDE` in the workflow file or as a workflow input:
+```yaml
+env:
+  RANCHER_BRANCHES_OVERRIDE: "release/v2.15 main"
+```
+
 ## Local usage
 
 ```bash
@@ -46,10 +68,14 @@ Add new Rancher versions as they're released. Remove EOL versions.
   --tag v0.4.2 \
   --rancher-dir /path/to/rancher \
   [--dry-run] \
-  [--remote upstream]
+  [--remote upstream] \
+  [--branches "release/v2.15,main"]
 ```
 
-`--dry-run` runs all local git work (commits to your rancher clone) but skips push and PR creation.
+Options:
+- `--dry-run` - runs all local git work (commits to your rancher clone) but skips push and PR creation
+- `--remote` - git remote name in your rancher clone (default: `origin`)
+- `--branches` - comma-separated list of branches to process (overrides default list)
 
 ## Step sequence
 
@@ -67,6 +93,7 @@ Add new Rancher versions as they're released. Remove EOL versions.
 | `TAG` | SCC Operator tag (e.g. `v0.4.2`) |
 | `RANCHER_DIR` | Path to local rancher/rancher clone |
 | `RANCHER_REMOTE` | Remote name in `RANCHER_DIR` (default: `origin`) |
+| `RANCHER_BRANCHES_OVERRIDE` | Space or comma-separated list of branches to process (overrides default) |
 | `DRY_RUN` | Set to `true` to skip push and PR creation |
 | `SOURCE_REPO` | Source repo for PR body (default: `rancher/scc-operator`) |
 

--- a/.github/workflows/push-to-rancher/common.sh
+++ b/.github/workflows/push-to-rancher/common.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Shared setup for push-to-rancher scripts. Source this file: source "$(dirname "$0")/common.sh"
+
+# Determine SCC_DIR (scc-operator root) from this script's location
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCC_DIR="${SCC_DIR:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+
+# Required: path to a local rancher/rancher clone
+RANCHER_DIR="${RANCHER_DIR:-}"
+
+# Remote name for rancher/rancher in RANCHER_DIR (may differ locally if using a fork)
+RANCHER_REMOTE="${RANCHER_REMOTE:-origin}"
+
+# Skip git commits, push, and PR creation when true
+DRY_RUN="${DRY_RUN:-false}"
+
+# Target branches in rancher/rancher to update
+RANCHER_BRANCHES=(
+  "release/v2.12"
+  "release/v2.13"
+  "release/v2.14"
+#  "release/v2.15"
+  "main"
+)
+
+# Docker registry to validate image existence
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-docker.io}"
+IMAGE_REPO="${IMAGE_REPO:-rancher/scc-operator}"
+
+# Write to GitHub step summary if available, and always print to stdout
+summary() {
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "$@" >> "$GITHUB_STEP_SUMMARY"
+  fi
+  echo "$@"
+}
+
+require_var() {
+  local var="$1"
+  if [ -z "${!var:-}" ]; then
+    echo "ERROR: $var is required" >&2
+    exit 1
+  fi
+}
+
+require_rancher_dir() {
+  require_var RANCHER_DIR
+  if [ ! -d "$RANCHER_DIR" ]; then
+    echo "ERROR: RANCHER_DIR '$RANCHER_DIR' does not exist" >&2
+    exit 1
+  fi
+}
+
+# Validate that the SCC Operator image exists in the registry
+validate_image_exists() {
+  local tag="$1"
+  local full_image="${IMAGE_REGISTRY}/${IMAGE_REPO}:${tag}"
+
+  summary "- Validating image exists: \`$full_image\`"
+
+  if ! docker manifest inspect "$full_image" >/dev/null 2>&1; then
+    echo "ERROR: Image $full_image does not exist in registry" >&2
+    echo "ERROR: Cannot proceed with PR creation until image is published" >&2
+    exit 1
+  fi
+
+  summary "  ✓ Image validated"
+}
+
+# Commit all changes in RANCHER_DIR if any exist. Does nothing if tree is clean.
+commit_if_changed() {
+  local message="$1"
+  if git -C "$RANCHER_DIR" diff --quiet --exit-code && [ -z "$(git -C "$RANCHER_DIR" status --porcelain)" ]; then
+    return 0
+  fi
+  git -C "$RANCHER_DIR" add .
+  git -C "$RANCHER_DIR" commit -m "$message"
+}

--- a/.github/workflows/push-to-rancher/common.sh
+++ b/.github/workflows/push-to-rancher/common.sh
@@ -75,11 +75,11 @@ validate_image_exists() {
   summary "  ✓ Image validated"
 }
 
-# Commit all changes in RANCHER_DIR if any exist. Does nothing if tree is clean.
+# Commit all changes in RANCHER_DIR if any exist. Returns 1 if no changes, 0 on success.
 commit_if_changed() {
   local message="$1"
   if git -C "$RANCHER_DIR" diff --quiet --exit-code && [ -z "$(git -C "$RANCHER_DIR" status --porcelain)" ]; then
-    return 0
+    return 1
   fi
   git -C "$RANCHER_DIR" add .
   git -C "$RANCHER_DIR" commit -m "$message"

--- a/.github/workflows/push-to-rancher/common.sh
+++ b/.github/workflows/push-to-rancher/common.sh
@@ -14,14 +14,22 @@ RANCHER_REMOTE="${RANCHER_REMOTE:-origin}"
 # Skip git commits, push, and PR creation when true
 DRY_RUN="${DRY_RUN:-false}"
 
-# Target branches in rancher/rancher to update
-RANCHER_BRANCHES=(
+# Target branches in rancher/rancher to update (default)
+DEFAULT_RANCHER_BRANCHES=(
   "release/v2.12"
   "release/v2.13"
   "release/v2.14"
   "release/v2.15"
   "main"
 )
+
+# Allow override via RANCHER_BRANCHES_OVERRIDE (comma or space separated)
+if [ -n "${RANCHER_BRANCHES_OVERRIDE:-}" ]; then
+  # Convert to array, handling both comma and space separators
+  IFS=',' read -ra RANCHER_BRANCHES <<< "${RANCHER_BRANCHES_OVERRIDE// /,}"
+else
+  RANCHER_BRANCHES=("${DEFAULT_RANCHER_BRANCHES[@]}")
+fi
 
 # Docker registry to validate image existence
 IMAGE_REGISTRY="${IMAGE_REGISTRY:-docker.io}"

--- a/.github/workflows/push-to-rancher/common.sh
+++ b/.github/workflows/push-to-rancher/common.sh
@@ -30,6 +30,7 @@ if [ -n "${RANCHER_BRANCHES_OVERRIDE:-}" ]; then
 else
   RANCHER_BRANCHES=("${DEFAULT_RANCHER_BRANCHES[@]}")
 fi
+export RANCHER_BRANCHES
 
 # Docker registry to validate image existence
 IMAGE_REGISTRY="${IMAGE_REGISTRY:-docker.io}"

--- a/.github/workflows/push-to-rancher/common.sh
+++ b/.github/workflows/push-to-rancher/common.sh
@@ -19,7 +19,7 @@ RANCHER_BRANCHES=(
   "release/v2.12"
   "release/v2.13"
   "release/v2.14"
-#  "release/v2.15"
+  "release/v2.15"
   "main"
 )
 

--- a/.github/workflows/push-to-rancher/create-prs.sh
+++ b/.github/workflows/push-to-rancher/create-prs.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Creates PRs to rancher/rancher branches with updated SCC Operator image.
+#
+# Required env vars:
+#   TAG          - SCC Operator tag (e.g. v0.4.2)
+#   RANCHER_DIR  - Path to rancher/rancher clone
+#   GH_TOKEN     - GitHub token for PR creation
+#   SOURCE_REPO  - Source repo for PR body (e.g. rancher/scc-operator)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_var TAG
+require_var GH_TOKEN
+require_rancher_dir
+
+SOURCE_REPO="${SOURCE_REPO:-rancher/scc-operator}"
+
+# Configure git in rancher clone
+git -C "$RANCHER_DIR" config user.name "github-actions[bot]"
+git -C "$RANCHER_DIR" config user.email "github-actions[bot]@users.noreply.github.com"
+
+summary ""
+summary "## Processing branches"
+
+FAILED_BRANCHES=()
+
+for TARGET_BRANCH in "${RANCHER_BRANCHES[@]}"; do
+  summary ""
+  summary "### Branch: \`$TARGET_BRANCH\`"
+
+  # Fetch and checkout target branch
+  if ! git -C "$RANCHER_DIR" fetch "$RANCHER_REMOTE" "$TARGET_BRANCH" 2>&1; then
+    summary "  ⚠️  Failed to fetch branch \`$TARGET_BRANCH\` - skipping"
+    FAILED_BRANCHES+=("$TARGET_BRANCH (fetch failed)")
+    continue
+  fi
+
+  git -C "$RANCHER_DIR" checkout -B "$TARGET_BRANCH" "$RANCHER_REMOTE/$TARGET_BRANCH"
+
+  # Create feature branch
+  BRANCH_NAME="bot/scc-operator-${TAG}-$(date +%s)"
+  git -C "$RANCHER_DIR" checkout -b "$BRANCH_NAME"
+
+  # Update build.yaml
+  export TAG RANCHER_DIR
+  if ! bash "$SCRIPT_DIR/update-build-yaml.sh"; then
+    summary "  ⚠️  Failed to update build.yaml - skipping"
+    FAILED_BRANCHES+=("$TARGET_BRANCH (update failed)")
+    git -C "$RANCHER_DIR" checkout "$TARGET_BRANCH"
+    git -C "$RANCHER_DIR" branch -D "$BRANCH_NAME" || true
+    continue
+  fi
+
+  # Run go generate (extract first directive from generate.go)
+  GENERATE_FILE="$RANCHER_DIR/generate.go"
+  if [ ! -f "$GENERATE_FILE" ]; then
+    summary "  ⚠️  generate.go not found - skipping"
+    FAILED_BRANCHES+=("$TARGET_BRANCH (no generate.go)")
+    git -C "$RANCHER_DIR" checkout "$TARGET_BRANCH"
+    git -C "$RANCHER_DIR" branch -D "$BRANCH_NAME" || true
+    continue
+  fi
+
+  # Extract first //go:generate directive
+  GENERATE_CMD=$(grep -m 1 '^//go:generate' "$GENERATE_FILE" | sed 's|^//go:generate ||')
+  if [ -z "$GENERATE_CMD" ]; then
+    summary "  ⚠️  No go:generate directive found in generate.go - skipping"
+    FAILED_BRANCHES+=("$TARGET_BRANCH (no generate directive)")
+    git -C "$RANCHER_DIR" checkout "$TARGET_BRANCH"
+    git -C "$RANCHER_DIR" branch -D "$BRANCH_NAME" || true
+    continue
+  fi
+
+  summary "  - Running: \`$GENERATE_CMD\`"
+  if ! (cd "$RANCHER_DIR" && eval "$GENERATE_CMD"); then
+    summary "  ⚠️  go generate failed - skipping"
+    FAILED_BRANCHES+=("$TARGET_BRANCH (go generate failed)")
+    git -C "$RANCHER_DIR" checkout "$TARGET_BRANCH"
+    git -C "$RANCHER_DIR" branch -D "$BRANCH_NAME" || true
+    continue
+  fi
+
+  # Commit changes
+  COMMIT_MSG="Update SCC Operator to ${TAG}
+
+Automated update from ${SOURCE_REPO} release ${TAG}"
+
+  if ! commit_if_changed "$COMMIT_MSG"; then
+    summary "  ℹ️  No changes detected - skipping"
+    git -C "$RANCHER_DIR" checkout "$TARGET_BRANCH"
+    git -C "$RANCHER_DIR" branch -D "$BRANCH_NAME" || true
+    continue
+  fi
+
+  if [ "$DRY_RUN" = "true" ]; then
+    summary "  ✓ Changes committed (dry-run, not pushing)"
+    git -C "$RANCHER_DIR" checkout "$TARGET_BRANCH"
+    continue
+  fi
+
+  # Push branch
+  summary "  - Pushing branch \`$BRANCH_NAME\`"
+  if ! git -C "$RANCHER_DIR" push -u "$RANCHER_REMOTE" "$BRANCH_NAME"; then
+    summary "  ⚠️  Failed to push branch - skipping PR creation"
+    FAILED_BRANCHES+=("$TARGET_BRANCH (push failed)")
+    git -C "$RANCHER_DIR" checkout "$TARGET_BRANCH"
+    continue
+  fi
+
+  # Create PR
+  summary "  - Creating PR..."
+  PR_BODY="## Summary
+Update SCC Operator image to [\`${TAG}\`](https://github.com/${SOURCE_REPO}/releases/tag/${TAG})
+
+## Changes
+- Updated \`defaultSccOperatorImage\` in \`build.yaml\`
+- Ran \`go generate ./pkg/...\` to update generated files"
+
+  if gh pr create \
+    --repo rancher/rancher \
+    --base "$TARGET_BRANCH" \
+    --head "$BRANCH_NAME" \
+    --title "Update SCC Operator to ${TAG}" \
+    --body "$PR_BODY" \
+    --label "status/auto-created" 2>&1; then
+    summary "  ✓ PR created successfully"
+  else
+    summary "  ⚠️  Failed to create PR"
+    FAILED_BRANCHES+=("$TARGET_BRANCH (PR creation failed)")
+  fi
+
+  # Return to target branch for next iteration
+  git -C "$RANCHER_DIR" checkout "$TARGET_BRANCH"
+done
+
+summary ""
+summary "## Summary"
+
+if [ ${#FAILED_BRANCHES[@]} -eq 0 ]; then
+  summary "✅ All branches processed successfully"
+else
+  summary "⚠️  Some branches failed:"
+  for branch in "${FAILED_BRANCHES[@]}"; do
+    summary "  - $branch"
+  done
+  exit 1
+fi

--- a/.github/workflows/push-to-rancher/create-prs.sh
+++ b/.github/workflows/push-to-rancher/create-prs.sh
@@ -112,6 +112,10 @@ Automated update from ${SOURCE_REPO} release ${TAG}"
 
   # Create PR
   summary "  - Creating PR..."
+
+  # Format branch name for title: strip "release/" prefix
+  BRANCH_LABEL="${TARGET_BRANCH#release/}"
+
   PR_BODY="## Summary
 Update SCC Operator image to [\`${TAG}\`](https://github.com/${SOURCE_REPO}/releases/tag/${TAG})
 
@@ -123,7 +127,7 @@ Update SCC Operator image to [\`${TAG}\`](https://github.com/${SOURCE_REPO}/rele
     --repo rancher/rancher \
     --base "$TARGET_BRANCH" \
     --head "$BRANCH_NAME" \
-    --title "Update SCC Operator to ${TAG}" \
+    --title "[${BRANCH_LABEL}] Update SCC Operator to ${TAG}" \
     --body "$PR_BODY" \
     --label "status/auto-created" 2>&1; then
     summary "  ✓ PR created successfully"

--- a/.github/workflows/push-to-rancher/create-prs.sh
+++ b/.github/workflows/push-to-rancher/create-prs.sh
@@ -34,11 +34,19 @@ for TARGET_BRANCH in "${RANCHER_BRANCHES[@]}"; do
     continue
   fi
 
-  git -C "$RANCHER_DIR" checkout -B "$TARGET_BRANCH" "$RANCHER_REMOTE/$TARGET_BRANCH"
+  if ! git -C "$RANCHER_DIR" checkout -B "$TARGET_BRANCH" "$RANCHER_REMOTE/$TARGET_BRANCH" 2>&1; then
+    summary "  ⚠️  Failed to checkout branch \`$TARGET_BRANCH\` - skipping"
+    FAILED_BRANCHES+=("$TARGET_BRANCH (checkout failed)")
+    continue
+  fi
 
   # Create feature branch
   BRANCH_NAME="bot/scc-operator-${TAG}-$(date +%s)"
-  git -C "$RANCHER_DIR" checkout -b "$BRANCH_NAME"
+  if ! git -C "$RANCHER_DIR" checkout -b "$BRANCH_NAME" 2>&1; then
+    summary "  ⚠️  Failed to create branch \`$BRANCH_NAME\` - skipping"
+    FAILED_BRANCHES+=("$TARGET_BRANCH (branch creation failed)")
+    continue
+  fi
 
   # Update build.yaml
   export TAG RANCHER_DIR
@@ -88,7 +96,13 @@ Automation: push-to-rancher
 Created-by: scc-operator-release-integration"
 
   if ! commit_if_changed "$COMMIT_MSG"; then
-    summary "  ℹ️  No changes detected - skipping"
+    exit_code=$?
+    if [ $exit_code -eq 1 ]; then
+      summary "  ℹ️  No changes detected - skipping"
+    else
+      summary "  ⚠️  Failed to commit changes - skipping"
+      FAILED_BRANCHES+=("$TARGET_BRANCH (commit failed)")
+    fi
     git -C "$RANCHER_DIR" checkout "$TARGET_BRANCH"
     git -C "$RANCHER_DIR" branch -D "$BRANCH_NAME" || true
     continue

--- a/.github/workflows/push-to-rancher/create-prs.sh
+++ b/.github/workflows/push-to-rancher/create-prs.sh
@@ -18,10 +18,6 @@ require_rancher_dir
 
 SOURCE_REPO="${SOURCE_REPO:-rancher/scc-operator}"
 
-# Configure git in rancher clone
-git -C "$RANCHER_DIR" config user.name "github-actions[bot]"
-git -C "$RANCHER_DIR" config user.email "github-actions[bot]@users.noreply.github.com"
-
 summary ""
 summary "## Processing branches"
 
@@ -86,7 +82,10 @@ for TARGET_BRANCH in "${RANCHER_BRANCHES[@]}"; do
   # Commit changes
   COMMIT_MSG="Update SCC Operator to ${TAG}
 
-Automated update from ${SOURCE_REPO} release ${TAG}"
+Automated update from ${SOURCE_REPO} release ${TAG}
+
+Automation: push-to-rancher
+Created-by: scc-operator-release-integration"
 
   if ! commit_if_changed "$COMMIT_MSG"; then
     summary "  ℹ️  No changes detected - skipping"

--- a/.github/workflows/push-to-rancher/create-prs.sh
+++ b/.github/workflows/push-to-rancher/create-prs.sh
@@ -97,7 +97,7 @@ Created-by: scc-operator-release-integration"
 
   if ! commit_if_changed "$COMMIT_MSG"; then
     exit_code=$?
-    if [ $exit_code -eq 1 ]; then
+    if [ "$exit_code" -eq 1 ]; then
       summary "  ℹ️  No changes detected - skipping"
     else
       summary "  ⚠️  Failed to commit changes - skipping"

--- a/.github/workflows/push-to-rancher/run-gha.sh
+++ b/.github/workflows/push-to-rancher/run-gha.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# GHA entry point: orchestrates the full rancher/rancher update workflow.
+# Called from push-to-rancher.yaml after token generation.
+#
+# Required env vars (set by push-to-rancher.yaml or release.yml):
+#   TAG          - SCC Operator tag (e.g. v0.4.2)
+#   GH_TOKEN     - GitHub app token with access to rancher/rancher
+#   SOURCE_REPO  - source repo (github.repository)
+#   SCC_DIR      - path to scc-operator workspace ($GITHUB_WORKSPACE)
+#   RANCHER_DIR  - path to clone rancher/rancher into
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_var TAG
+require_var GH_TOKEN
+
+export SCC_DIR RANCHER_DIR DRY_RUN
+
+summary "## Push to rancher/rancher"
+summary "- Tag: \`$TAG\`"
+summary "- Target branches: \`${RANCHER_BRANCHES[*]}\`"
+summary ""
+
+# Validate image exists before proceeding
+validate_image_exists "$TAG"
+
+# Clone rancher/rancher
+summary "- Cloning rancher/rancher..."
+git clone "https://oauth2:${GH_TOKEN}@github.com/rancher/rancher.git" "$RANCHER_DIR"
+
+summary ""
+summary "## Creating PRs"
+
+export SOURCE_REPO="${SOURCE_REPO:-rancher/scc-operator}"
+bash "$SCRIPT_DIR/create-prs.sh"
+
+summary ""
+summary "## Workflow Complete"

--- a/.github/workflows/push-to-rancher/run-gha.sh
+++ b/.github/workflows/push-to-rancher/run-gha.sh
@@ -8,6 +8,9 @@
 #   SOURCE_REPO  - source repo (github.repository)
 #   SCC_DIR      - path to scc-operator workspace ($GITHUB_WORKSPACE)
 #   RANCHER_DIR  - path to clone rancher/rancher into
+#
+# Optional env vars:
+#   RANCHER_BRANCHES_OVERRIDE - space or comma-separated list of branches to process
 
 set -euo pipefail
 
@@ -17,7 +20,7 @@ source "$SCRIPT_DIR/common.sh"
 require_var TAG
 require_var GH_TOKEN
 
-export SCC_DIR RANCHER_DIR DRY_RUN
+export SCC_DIR RANCHER_DIR DRY_RUN RANCHER_BRANCHES_OVERRIDE
 
 summary "## Push to rancher/rancher"
 summary "- Tag: \`$TAG\`"

--- a/.github/workflows/push-to-rancher/run-gha.sh
+++ b/.github/workflows/push-to-rancher/run-gha.sh
@@ -31,6 +31,10 @@ validate_image_exists "$TAG"
 summary "- Cloning rancher/rancher..."
 git clone "https://oauth2:${GH_TOKEN}@github.com/rancher/rancher.git" "$RANCHER_DIR"
 
+# Configure git identity for commits (GHA only - fresh clone deleted at workflow end)
+git -C "$RANCHER_DIR" config user.name "github-actions[bot]"
+git -C "$RANCHER_DIR" config user.email "github-actions[bot]@users.noreply.github.com"
+
 summary ""
 summary "## Creating PRs"
 

--- a/.github/workflows/push-to-rancher/run-local.sh
+++ b/.github/workflows/push-to-rancher/run-local.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Local entry point for testing push-to-rancher workflow.
+#
+# Usage:
+#   ./run-local.sh --tag v0.4.2 --rancher-dir /path/to/rancher [--dry-run] [--remote upstream]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Defaults
+TAG=""
+RANCHER_DIR=""
+DRY_RUN="false"
+RANCHER_REMOTE="origin"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --tag)
+      TAG="$2"
+      shift 2
+      ;;
+    --rancher-dir)
+      RANCHER_DIR="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    --remote)
+      RANCHER_REMOTE="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: $0 --tag TAG --rancher-dir DIR [--dry-run] [--remote REMOTE]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Validate required args
+if [ -z "$TAG" ]; then
+  echo "ERROR: --tag is required" >&2
+  exit 1
+fi
+
+if [ -z "$RANCHER_DIR" ]; then
+  echo "ERROR: --rancher-dir is required" >&2
+  exit 1
+fi
+
+if [ ! -d "$RANCHER_DIR" ]; then
+  echo "ERROR: rancher-dir '$RANCHER_DIR' does not exist" >&2
+  exit 1
+fi
+
+# Set up environment
+export TAG RANCHER_DIR RANCHER_REMOTE DRY_RUN
+export GH_TOKEN="${GH_TOKEN:-$(gh auth token)}"
+
+# Source common for validation functions
+source "$SCRIPT_DIR/common.sh"
+
+echo "## Push to rancher/rancher (local)"
+echo "- Tag: $TAG"
+echo "- Rancher dir: $RANCHER_DIR"
+echo "- Remote: $RANCHER_REMOTE"
+echo "- Dry run: $DRY_RUN"
+echo ""
+
+# Validate image exists
+validate_image_exists "$TAG"
+
+echo ""
+echo "## Creating PRs"
+
+export SOURCE_REPO="${SOURCE_REPO:-rancher/scc-operator}"
+bash "$SCRIPT_DIR/create-prs.sh"
+
+echo ""
+echo "## Workflow Complete"
+
+if [ "$DRY_RUN" = "true" ]; then
+  echo ""
+  echo "NOTE: This was a dry run. Changes were committed locally but not pushed."
+  echo "Review the commits in $RANCHER_DIR and run without --dry-run to push and create PRs."
+fi

--- a/.github/workflows/push-to-rancher/run-local.sh
+++ b/.github/workflows/push-to-rancher/run-local.sh
@@ -13,6 +13,7 @@ TAG=""
 RANCHER_DIR=""
 DRY_RUN="false"
 RANCHER_REMOTE="origin"
+RANCHER_BRANCHES_OVERRIDE=""
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -33,9 +34,13 @@ while [[ $# -gt 0 ]]; do
       RANCHER_REMOTE="$2"
       shift 2
       ;;
+    --branches)
+      RANCHER_BRANCHES_OVERRIDE="$2"
+      shift 2
+      ;;
     *)
       echo "Unknown option: $1" >&2
-      echo "Usage: $0 --tag TAG --rancher-dir DIR [--dry-run] [--remote REMOTE]" >&2
+      echo "Usage: $0 --tag TAG --rancher-dir DIR [--dry-run] [--remote REMOTE] [--branches BRANCHES]" >&2
       exit 1
       ;;
   esac
@@ -58,7 +63,7 @@ if [ ! -d "$RANCHER_DIR" ]; then
 fi
 
 # Set up environment
-export TAG RANCHER_DIR RANCHER_REMOTE DRY_RUN
+export TAG RANCHER_DIR RANCHER_REMOTE DRY_RUN RANCHER_BRANCHES_OVERRIDE
 export GH_TOKEN="${GH_TOKEN:-$(gh auth token)}"
 
 # Source common for validation functions
@@ -69,6 +74,7 @@ echo "- Tag: $TAG"
 echo "- Rancher dir: $RANCHER_DIR"
 echo "- Remote: $RANCHER_REMOTE"
 echo "- Dry run: $DRY_RUN"
+echo "- Target branches: ${RANCHER_BRANCHES[*]}"
 echo ""
 
 # Validate image exists

--- a/.github/workflows/push-to-rancher/update-build-yaml.sh
+++ b/.github/workflows/push-to-rancher/update-build-yaml.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Updates defaultSccOperatorImage in build.yaml to the specified tag.
+#
+# Required env vars:
+#   TAG          - SCC Operator tag (e.g. v0.4.2)
+#   RANCHER_DIR  - Path to rancher/rancher clone
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+require_var TAG
+require_rancher_dir
+
+BUILD_YAML="$RANCHER_DIR/build.yaml"
+
+if [ ! -f "$BUILD_YAML" ]; then
+  echo "ERROR: build.yaml not found at $BUILD_YAML" >&2
+  exit 1
+fi
+
+# Remove leading 'v' if present for consistency
+TAG_NO_V="${TAG#v}"
+
+# Update the defaultSccOperatorImage field
+# Use yq for safe YAML editing
+yq eval ".defaultSccOperatorImage = \"rancher/scc-operator:v${TAG_NO_V}\"" -i "$BUILD_YAML"
+
+summary "  - Updated build.yaml: \`defaultSccOperatorImage: rancher/scc-operator:v${TAG_NO_V}\`"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,9 +129,18 @@ jobs:
     name: Un-draft release
     runs-on: ubuntu-latest
     needs: [ ci, goreleaser, image ]
+    outputs:
+      is_stable: ${{ steps.semver_check.outputs.HAS_PRERELEASE == 'false' }}
     permissions:
       contents: write
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check SemVer Characteristics
+        id: semver_check
+        run: bash ./.github/scripts/check-semver "${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+
       - name: Fully publish release (retry until visible)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -139,7 +148,7 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ github.ref_name }}"
-          
+
           for i in {1..12}; do
             if gh release view -R "${{ github.repository }}" "$tag" >/dev/null 2>&1; then
               gh release edit -R "${{ github.repository }}" "$tag" --draft=false
@@ -148,6 +157,14 @@ jobs:
             echo "Release '$tag' not found yet (attempt $i/12). Sleeping 10s..."
             sleep 10
           done
-          
+
           echo "Release '$tag' still not found after retries; failing."
           exit 1
+
+  push-to-rancher:
+    name: Push to rancher/rancher
+    needs: [ release ]
+    if: ${{ github.repository == 'rancher/scc-operator' && needs.release.outputs.is_stable == 'true' }}
+    uses: ./.github/workflows/push-to-rancher.yml
+    with:
+      tag: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     container:
       image: ghcr.io/rancher/ci-image/go1.25
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
@@ -52,7 +52,7 @@ jobs:
           echo "artifacts=$(tr -d '\n\r' < dist/artifacts.json)" >> "${GITHUB_OUTPUT}"
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: dist/scc-operator_*
 
@@ -67,7 +67,7 @@ jobs:
       image: ghcr.io/rancher/ci-image/go1.25
     steps:
       - name : Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: "Read Secrets"
         if: github.repository == 'rancher/scc-operator'
@@ -82,7 +82,7 @@ jobs:
 
         # This encapsulates: login, qemu, build/push
       - name: Build and push scc-operator image (dockerhub and prime stg)
-        uses: rancher/ecm-distro-tools/actions/publish-image@49656efa72e90062a70fac1a85ad121f4873a6a0 # v0.74.4
+        uses: rancher/ecm-distro-tools/actions/publish-image@b558c3371d4a363f131e31a87d5c47dae2bbebe7 # v0.75.1
         with:
           image: 'scc-operator'
           tag: ${{ github.ref_name }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: Build and push scc-operator image (prod)
         if: ${{github.repository == 'rancher/scc-operator' && steps.semver_check.outputs.HAS_PRERELEASE == 'false'}}
-        uses: rancher/ecm-distro-tools/actions/publish-image@49656efa72e90062a70fac1a85ad121f4873a6a0 # v0.74.4
+        uses: rancher/ecm-distro-tools/actions/publish-image@b558c3371d4a363f131e31a87d5c47dae2bbebe7 # v0.75.1
         with:
           image: 'scc-operator'
           tag: ${{ github.ref_name }}
@@ -135,7 +135,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check SemVer Characteristics
         id: semver_check

--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   call-workflow:
-    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@a9fa41f899dfd0b3f211f7a897ec19ec7c4462c4 # v1.0.3
+    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@faa051782ecc7002d78b37640974fa6aaf412c53 # v1.0.6
     with:
       configMigration: ${{ inputs.configMigration || 'true' }}
       logLevel: ${{ inputs.logLevel || 'info' }}

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -18,17 +18,17 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Install Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: 'stable'
 
       - name: Install Updatecli
-        uses: updatecli/updatecli-action@5bda7da77bf4d181bce5f807d73d832b62062acf # v3.3.0
+        uses: updatecli/updatecli-action@5dfc616e57b07d2302c3f37e5b72a4ead82dbbf8 # v3.4.0
 
       - name: Delete leftover UpdateCLI branches
         run: |

--- a/scripts/ci
+++ b/scripts/ci
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 echo "Starting CI for scc-operator"
 

--- a/scripts/gotools-sync
+++ b/scripts/gotools-sync
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")/.."
 
 # Parse command line args
 SKIP_TIDY=false

--- a/scripts/gotools-validate
+++ b/scripts/gotools-validate
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")/.."
 
 echo "Validating go.mod versions across main and gotools..."
 
@@ -47,7 +47,7 @@ for modfile in gotools/*/go.mod; do
     fi
 done
 
-if [ $ERRORS -eq 0 ]; then
+if [ "$ERRORS" -eq 0 ]; then
     echo "✓ All go.mod files are in sync"
     exit 0
 else

--- a/scripts/package
+++ b/scripts/package
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-source $(dirname $0)/version
+source "$(dirname "$0")/version"
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")/.."
 
 echo "Starting \`${BUILD_TARGET}\` image packaging:";
 
@@ -11,9 +11,9 @@ DOCKERFILE=package/Dockerfile${DOCKER_TARGET}
 echo "Building \`${IMAGE}\` from \`${DOCKERFILE}\`:";
 
 if [[ ${USE_DOCKER_BUILDX} -eq 1 ]]; then
-  docker buildx build --platform linux/amd64,linux/arm64 -f "${DOCKERFILE}" --build-arg RANCHER_PROJECT_MONITORING=$RANCHER_PROJECT_MONITORING -t "${IMAGE}" .
+  docker buildx build --platform linux/amd64,linux/arm64 -f "${DOCKERFILE}" --build-arg RANCHER_PROJECT_MONITORING="$RANCHER_PROJECT_MONITORING" -t "${IMAGE}" .
 else
-  docker build -f "${DOCKERFILE}" --build-arg RANCHER_PROJECT_MONITORING=$RANCHER_PROJECT_MONITORING -t "${IMAGE}" .
+  docker build -f "${DOCKERFILE}" --build-arg RANCHER_PROJECT_MONITORING="$RANCHER_PROJECT_MONITORING" -t "${IMAGE}" .
 fi
 
 echo "Completed building ${IMAGE} container image"

--- a/scripts/test
+++ b/scripts/test
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")/.."
 
 echo "Running golang tests..."
 

--- a/scripts/validate-generated
+++ b/scripts/validate-generated
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")/.."
 
 echo "Validating generated files are up to date..."
 


### PR DESCRIPTION
This PR automates the creation of PRs to `r/r` repo when we tag a stable release.

This does not automate non-stable releases as not all unstable tags need to be "shipped". This reduces the noise that automations creating PRs can cause if the PRs are not desired. As a happy compromise we can manually trigger the "Push to Rancher" workflow with a specified tag for PRs to be generated.